### PR TITLE
Fixed TEST_CALL_FILTER bugs in dCGH Snakefile

### DIFF
--- a/RD_setup/Snakefile
+++ b/RD_setup/Snakefile
@@ -19,10 +19,15 @@ SUNK_WNDS_PKL="/net/eichler/vol7/home/psudmant/EEE_Lab/1000G/1000genomesScripts/
 
 genomes=["Gorilla_beringei_beringei_Imfura","Gorilla_beringei_beringei_Kaboko","Gorilla_beringei_beringei_Maisha","Gorilla_beringei_beringei_Tuck","Gorilla_beringei_beringei_Turimaso","Gorilla_beringei_beringei_Umurimo","Gorilla_beringei_beringei_Zirikana","Gorilla_beringei_graueri_Dunia","Gorilla_beringei_graueri_Itebero","Gorilla_beringei_graueri_Ntabwoba","Gorilla_beringei_graueri_Pinga","Gorilla_beringei_graueri_Serufuli","Gorilla_beringei_graueri_Tumani","Gorilla_gorilla_gorilla-9752_Suzie","Gorilla_gorilla_gorilla-9753_Kokomo","Gorilla_gorilla_gorilla-A962_Amani","Gorilla_gorilla_gorilla-B642_Akiba_Beri","Gorilla_gorilla_gorilla-B643_Choomba","Gorilla_gorilla_gorilla_Banjo","Gorilla_gorilla_gorilla_Coco","Gorilla_gorilla_gorilla-KB6039_Oko","Gorilla_gorilla_gorilla-X00108_Abe","Gorilla_gorilla_gorilla-X00109_Tzambo"]
 
+###g_to_index is a dictionary with sample names as keys and directory prefixes as values. 
+###This allows analysis scripts to find the wssd outfiles, which by default will be in mapping/{genome}/{value}_merged.sorted/wssd_out_file
+ 
 g_to_index = {}
 for f in glob.glob("%s/*"%SPLIT_DIR):
     g = open(f).readline().split()[0]
     g_to_index[g] = f 
+
+###
 
 rule all:
     input: expand("%s/{genome}_{type}.bb.trackdef"%(BROWSER_TRACK_OUTDIR), genome=genomes, type=["sunk","wssd"])
@@ -44,33 +49,33 @@ rule make_sunk_DTS:
     input: "bac_analysis/{genome}/_filtered_libs_analysis.GC3v2-NOWM-pad36/fit_params-CALKAN-NOWM-pad36-simple-dim0-ed-0.per_bac_params"
     output: "{DTS_DIR}/500_bp_sunk_slide/{WND_WIDTH}_bp_{genome}"
     params: sge_opts="-l mfree=12G -N DTS_SUNK_{genome}", indiv="{genome}"
-    shell: "python ~psudmant/EEE_Lab/1000G/1000genomesScripts/windowed_analysis/DTS_window_analysis/generate_windowed_cp_ests.py \
+    run: shell("python ~psudmant/EEE_Lab/1000G/1000genomesScripts/windowed_analysis/DTS_window_analysis/generate_windowed_cp_ests.py \
                     --contig_file {CONTIGS}  \
                     --mask_file {MASK_TRACK} \
-                    --genome  %s  \
+                    --genome  {params.indiv}  \
                     --out_prefix {DTS_DIR}/{SUNK_DIR}/{WND_WIDTH}_bp   \
                     --wnd_pickle {SUNK_WNDS_PKL}\
                     --wnd_contig_file {SUNK_WNDS_PKL}.contigs  \
-                    --wnd_width {WND_WIDTH}"%g_to_index[params.indiv]
+                    --wnd_width {WND_WIDTH}"%g_to_index[params.indiv])
 
 rule make_DTS:
     input: "bac_analysis/{genome}/_filtered_libs_analysis.GC3v2-NOWM-pad36/fit_params-CALKAN-NOWM-pad36-simple-dim0-ed-0.per_bac_params"
     output: "{DTS_DIR}/500_bp_slide/{WND_WIDTH}_bp_{genome}"
     params: sge_opts="-l mfree=12G -N DTS_{genome}", indiv="{genome}"
-    shell: "python ~psudmant/EEE_Lab/1000G/1000genomesScripts/windowed_analysis/DTS_window_analysis/generate_windowed_cp_ests.py \
+    run: shell("python ~psudmant/EEE_Lab/1000G/1000genomesScripts/windowed_analysis/DTS_window_analysis/generate_windowed_cp_ests.py \
                     --contig_file {CONTIGS}  \
                     --mask_file {MASK_TRACK} \
                     --genome  %s  \
                     --out_prefix {DTS_DIR}/{WSSD_DIR}/{WND_WIDTH}_bp   \
                     --wnd_pickle {WNDS_PKL}\
                     --wnd_contig_file {WNDS_PKL}.contigs  \
-                    --wnd_width {WND_WIDTH}"%g_to_index[params.indiv]
+                    --wnd_width {WND_WIDTH}"%g_to_index[params.indiv])
 
 rule get_params:
     input: "primary_analysis/{genome}/combined_corrected_wssd/wssd.combined_corrected.GC3.v2"
     output:  "bac_analysis/{genome}/_filtered_libs_analysis.GC3v2-NOWM-pad36/fit_params-CALKAN-NOWM-pad36-simple-dim0-ed-0.per_bac_params"
     params: sge_opts="-l mfree=4G -N params_{genome}", indiv="{genome}"
-    shell: "python ~psudmant/EEE_Lab/1000G/1000genomesScripts/get_params_on_control_regions/analyze_control_regions.py  \
+    run: shell("python ~psudmant/EEE_Lab/1000G/1000genomesScripts/get_params_on_control_regions/analyze_control_regions.py  \
                                     --in_bac_regions /net/gs/vol1/home/psudmant/genomes/control_bacs.masked/control_bacs_locations/control_location_hg19  \
                                     --in_contigs {CONTIGS} \
                                     --in_mask {MASK_TRACK} \
@@ -80,7 +85,7 @@ rule get_params:
                                     --wssd_file_name wssd.combined_corrected.GC3.v2 \
                                     --output_directory _filtered_libs_analysis.GC3v2-NOWM-pad36 \
                                     --edits -1:0  \
-                                    --type simple"%g_to_index[params.indiv]
+                                    --type simple"%g_to_index[params.indiv])
                                     #--only_use_cps 2  ONLY FOR NON-HUMANS
                                     
 
@@ -88,7 +93,7 @@ rule WSSD_cc:
     input:  "bac_analysis/{genome}/{genome}/summary_stats_dim0.txt"
     output: "primary_analysis/{genome}/combined_corrected_wssd/wssd.combined_corrected.GC3.v2"
     params: sge_opts="-l mfree=14G -N wssd_{genome}", indiv="{genome}"
-    shell: "python ~psudmant/EEE_Lab/1000G/1000genomesScripts/wssd_make_combined_adjusted_tracks/wssd_make_combined_adjusted_tracks.py \
+    run: shell("python ~psudmant/EEE_Lab/1000G/1000genomesScripts/wssd_make_combined_adjusted_tracks/wssd_make_combined_adjusted_tracks.py \
                                     --contigLengths {CONTIGS} \
                                     --gc_width 200  \
                                     --in_genomes %s \
@@ -97,13 +102,13 @@ rule WSSD_cc:
                                     --input_wssd_file_names wssd_out_file \
                                     --max_correction 3  \
                                     --append_to_name .GC3.v2  \
-                                    --overide_thresh .01"%g_to_index[params.indiv]
+                                    --overide_thresh .01"%g_to_index[params.indiv])
 
 rule BAC:
     input:"bac_analysis/{genome}/{genome}/cn2-gc-depth-WG-W200-dim0.txt"
     output:"bac_analysis/{genome}/{genome}/summary_stats_dim0.txt"
     params: sge_opts="-l mfree=10G -N BAC_{genome}", indiv="{genome}"
-    shell: "python ~psudmant/EEE_Lab/dist_analysis/get_read_dists/run_bac_analysis.py  \
+    run: shell("python ~psudmant/EEE_Lab/dist_analysis/get_read_dists/run_bac_analysis.py  \
                             --sex_index {SEX_POP} \
                             --hg_mask_file {MASK_TRACK} \
                             --hg_contig {CONTIGS} \
@@ -112,13 +117,13 @@ rule BAC:
                             --bac_list_file /net/gs/vol1/home/psudmant/genomes/control_bacs.masked/control_bacs_locations/control_location_hg19 \
                             --input_genomes %s\
                             --input_wssd_file_names wssd_out_file \
-                            --genome HG19"%g_to_index[params.indiv]
+                            --genome HG19"%g_to_index[params.indiv])
 
 rule GetGC:
     input: "mapping/{genome}/{genome}/wssd_out_file"
     output:"bac_analysis/{genome}/{genome}/cn2-gc-depth-WG-W200-dim0.txt"
     params: sge_opts="-l mfree=6G -N GC_{genome}", indiv="{genome}"
-    shell: "python /net/eichler/vol7/home/psudmant/EEE_Lab/1000G/1000genomesScripts/get_gc_correction/get_gc_correction.py \
+    run: shell("python /net/eichler/vol7/home/psudmant/EEE_Lab/1000G/1000genomesScripts/get_gc_correction/get_gc_correction.py \
                                 --sex_pop_index {SEX_POP}  \
                                 --hg_mask_file {MASK_TRACK} \
                                 --hg_contig_file {CONTIGS} \
@@ -127,4 +132,4 @@ rule GetGC:
                                 --fn_DGV_flatfile /net/gs/vol2/home/psudmant/genomes/annotations/hg19/DGV/DGV_variation_hg19.annotation.DTS  \
                                 --fn_superdup_flatfile /net/gs/vol2/home/psudmant/genomes/annotations/hg19/superdups/genomicSuperDups_hg19.annotation.DTS  \
                                 --fn_genomic_gaps_flatfile /net/gs/vol2/home/psudmant/genomes/annotations/hg19/gaps/genomic_gaps_hg19.annotation.DTS  \
-                                --wssd_file wssd_out_file"%g_to_index[params.indiv]
+                                --wssd_file wssd_out_file"%g_to_index[params.indiv])

--- a/RD_setup/Snakefile
+++ b/RD_setup/Snakefile
@@ -5,10 +5,10 @@ MASK_TRACK="~psudmant/genomes/mask_tracks/HG19-noWM-pad36"
 SUNK_MASK_TRACK="/net/eichler/vol7/home/psudmant/genomes/sunk_tracks/hg19/hg19_sunk_depth_mask.dts"
 CONTIGS="~psudmant/genomes/contigs/hg19_contigs.txt"
 GC_TRACK="~psudmant/genomes/GC_tracks/hg19-gc-w200.GC_content"
-SPLIT_DIR="/net/eichler/vol7/home/psudmant/EEE_Lab/1000G/analysis_files/input_genomes_moved/hg19/GAGP/GAGP_II/split_GAGP_II/"
+SPLIT_DIR="/net/eichler/vol7/home/psudmant/EEE_Lab/1000G/analysis_files/input_genomes_moved/hg19/GAGP/GAGP_II/split_GAGP_II"
 WND_WIDTH=500
 
-DTS_DIR="/net/eichler/vol19/projects/human_population_sequencing/nobackups/psudmant/wnd_output_DTS/hg19/MTN_GORILLA/"
+DTS_DIR="/net/eichler/vol19/projects/human_population_sequencing/nobackups/psudmant/wnd_output_DTS/hg19/MTN_GORILLA"
 BROWSER_TRACK_OUTDIR="/net/eichler/vol13/browserTracks/peter/whole_genome_wssd/hg19_MNT_GORILLAS"
 
 WSSD_DIR="500_bp_slide"

--- a/RD_setup/Snakefile
+++ b/RD_setup/Snakefile
@@ -52,7 +52,7 @@ rule make_sunk_DTS:
     run: shell("python ~psudmant/EEE_Lab/1000G/1000genomesScripts/windowed_analysis/DTS_window_analysis/generate_windowed_cp_ests.py \
                     --contig_file {CONTIGS}  \
                     --mask_file {MASK_TRACK} \
-                    --genome  {params.indiv}  \
+                    --genome %s  \
                     --out_prefix {DTS_DIR}/{SUNK_DIR}/{WND_WIDTH}_bp   \
                     --wnd_pickle {SUNK_WNDS_PKL}\
                     --wnd_contig_file {SUNK_WNDS_PKL}.contigs  \

--- a/dCGH/Snakefile
+++ b/dCGH/Snakefile
@@ -11,7 +11,7 @@ import os
 BEGIN CONSTANTS
 """
 
-SCRIPT_DIR="/net/eichler/vol7/home/psudmant/EEE_Lab/projects/common_code/ssf_DTS_caller/"
+SCRIPT_DIR="/net/eichler/vol7/home/psudmant/EEE_Lab/projects/common_code/ssf_DTS_caller"
 
 DUP_TABIX="~psudmant/genomes/annotations/hg19/superdups/superdups.merged.bed.gz"
 GENE_TABIX="~psudmant/genomes/annotations/hg19/genes/refGene.txt_sorted.gz"
@@ -19,7 +19,7 @@ GC_TABIX="~psudmant/genomes/GC_tracks/hg19-gc-w200.GC_content.bed_sorted.gz"
 
 P_CUTOFF=0.0001
 
-DTS_DIR="input_DTS/500_bp_slide"
+DTS_DIR="DTS_files/500_bp_slide"
 DTS_REF_DIR=DTS_DIR
 GGLOB_DIR="gglob"
 
@@ -41,12 +41,13 @@ This section modifies how rule genotype_refine_breakpoints_by_chr_subset is run.
 
 TEST_CALL_FILTER = False
 
+ALL_CONTIGS = ["chr%d" % d for d in range(1,23)]
+
 if TEST_CALL_FILTER:
-    CONTIGS=["chr20"]
+    TEST_CONTIGS=["chr20"]
     PLOT_MODE="--do_plot"
-    #PLOT_MODE=""
 else:
-    CONTIGS=["chr%d" % d for d in range(1,23)]
+    TEST_CONTIGS=ALL_CONTIGS
     PLOT_MODE=""
 
 """End TEST_CALL_FILTER section"""
@@ -71,6 +72,12 @@ EXCLUDE=[]
 
 samples=list(set(samples)-set(EXCLUDE))
 
+DIRS_TO_MAKE = ["plotting/test", "log"]
+
+for path in DIRS_TO_MAKE:
+    if not os.path.exists(path):
+        os.makedirs(path)
+
 """
 END CONSTANTS
 """
@@ -81,7 +88,7 @@ LOAD MODULES, SET PYTHONPATH, AND CREATE INITIAL DIRECTORIES
 INIT_MODULES="module load python/2.7.2 numpy/1.6.1 scipy/0.10.0 hdf5/1.8.8 pytables/2.3.1_hdf5-1.8.8 networkx/1.6 fastahack/0.1 fastahack-python/0.1 tabix/0.2.6;"
 os.system("export PYTHONPATH=$PYTHONPATH:/net/eichler/vol7/home/psudmant/EEE_Lab/1000G/1000genomesScripts/:/net/eichler/vol7/home/psudmant/EEE_Lab/projects/common_code:/net/eichler/vol7/home/psudmant/EEE_Lab/projects/common_code/ssf_DTS_caller;")
 
-DIRS_TO_MAKE = ["log", "plot"]
+DIRS_TO_MAKE = ["log", "plot", "plotting/test"]
 
 os.system("mkdir -p %s" % ' '.join(DIRS_TO_MAKE))
 
@@ -97,7 +104,6 @@ rule export_callset:
     params: outdir="exported_callsets/%s"%(datestr)
     shell: "cp {input} {params.outdir}"
 
-
 rule make_table_of_simple_genotypes:
     input: "final_calls/final_genotypes"
     output: "final_calls/analysis_callsets/bi_allelic_genotypes"
@@ -105,7 +111,7 @@ rule make_table_of_simple_genotypes:
     shell: "{INIT_MODULES} python ~psudmant/EEE_Lab/projects/common_code/ssf_DTS_caller/filter_to_simple_gts.py --fn_gts {input} --fn_out {output} --exclude params.exclude"
 
 rule combine_by_chr:
-    input: expand("final_calls/by_chr/{contig}/{k}.genotypes",contig=CONTIGS, k=SUBSETS)
+    input: expand("final_calls/by_chr/{contig}/{k}.genotypes",contig=TEST_CONTIGS, k=SUBSETS)
     output: "final_calls/final_genotypes", "final_calls/final_calls.bed","final_calls/final_calls.filter_data"  
     params:  sge_opts="-l mfree=2G -N combine_contigs"
     run:
@@ -139,10 +145,12 @@ rule combine_by_chr:
         FOUT_filt.close()
         FOUT_gts.close()
 
+rule test_call_filter:
+    input: expand("final_calls/by_chr/{contig}/{k}.{ext}", contig=TEST_CONTIGS, k=SUBSETS, ext=["genotypes", "bed", "vcf"])
+    params: sge_opts=''
+
 rule clean_call_filter_test:
-    input: "final_calls/by_chr/{contig}/{k}.genotypes", "final_calls/by_chr/{contig}/{k}.bed", "final_calls/by_chr/{contig}/{k}.vcf"
-    params: contig = '{contig}'
-    shell: "rm -rf final_calls/by_chr/{params.contig}/*"
+    shell: "rm -rf final_calls/by_chr/*/*"
 
 rule genotype_refine_breakpoints_by_chr_subset:
     input: "all_resolved_calls/all_resolved_calls.gz"
@@ -153,7 +161,6 @@ rule genotype_refine_breakpoints_by_chr_subset:
             plot_out_dir="final_calls/by_chr/{contig}",
             subset_gglob_indivs=":".join([s.split("/")[-1] for s in samples])
     shell: "{INIT_MODULES} python {SCRIPT_DIR}/genotype_refined_call_sets.py --call_table {input} --dup_tabix {DUP_TABIX} --genotype_output {output[0]} --vcf_output {output[2]} --call_output {output[1]} --contig {params.contig} --visualizations_dir {params.plot_out_dir} --gglob_dir {GGLOB_DIR} --total_subsets {N_SUBSETS} --subset {params.curr_n} --subset_indivs {params.subset_gglob_indivs} {PLOT_MODE}"
-import shutil
 
 rule bgzip_all_refined_calls:       
     input: "all_resolved_calls/all_resolved_calls"
@@ -245,7 +252,7 @@ rule gzip:
 rule dCGH:
     input: "%s/500_bp_{sample}" % DTS_DIR, "%s/500_bp_{reference}" % DTS_REF_DIR
     output: "indiv_dCGH_files/{sample}.{reference}.segs" 
-    params: sge_opts="-l mfree=8G -N dCGH_{sample}_{reference}", contigs=":".join(CONTIGS), sample="{sample}", ref="{reference}"
+    params: sge_opts="-l mfree=8G -N dCGH_{sample}_{reference}", contigs=":".join(ALL_CONTIGS), sample="{sample}", ref="{reference}"
     run:
         if params.ref==params.sample:
             shell("touch {output[0]};")
@@ -259,5 +266,5 @@ rule pclean:
     shell: "rm -rf ./all_resolved_calls ./resolved_calls_per_indiv ./log ./beds_resolved_calls ./final_calls; mkdir ./log"
 
 rule fclean:
-    shell: "rm -rf ./log ./final_calls ./plotting/test/; mkdir ./log; mkdir ./plotting/test"
+    shell: "rm -rf ./log ./final_calls ./plot; mkdir ./log; mkdir ./plot"
 

--- a/dCGH/Snakefile
+++ b/dCGH/Snakefile
@@ -146,6 +146,7 @@ rule test_call_filter:
     params: sge_opts=''
 
 rule clean_call_filter_test:
+    params: sge_opts = ""
     shell: "rm -rf final_calls/by_chr/*/*"
 
 rule genotype_refine_breakpoints_by_chr_subset:

--- a/dCGH/Snakefile
+++ b/dCGH/Snakefile
@@ -72,7 +72,7 @@ EXCLUDE=[]
 
 samples=list(set(samples)-set(EXCLUDE))
 
-DIRS_TO_MAKE = ["plotting/test", "log"]
+DIRS_TO_MAKE = ["plotting/test", "plot", "log"]
 
 for path in DIRS_TO_MAKE:
     if not os.path.exists(path):
@@ -87,10 +87,6 @@ LOAD MODULES, SET PYTHONPATH, AND CREATE INITIAL DIRECTORIES
 """
 INIT_MODULES="module load python/2.7.2 numpy/1.6.1 scipy/0.10.0 hdf5/1.8.8 pytables/2.3.1_hdf5-1.8.8 networkx/1.6 fastahack/0.1 fastahack-python/0.1 tabix/0.2.6;"
 os.system("export PYTHONPATH=$PYTHONPATH:/net/eichler/vol7/home/psudmant/EEE_Lab/1000G/1000genomesScripts/:/net/eichler/vol7/home/psudmant/EEE_Lab/projects/common_code:/net/eichler/vol7/home/psudmant/EEE_Lab/projects/common_code/ssf_DTS_caller;")
-
-DIRS_TO_MAKE = ["log", "plot", "plotting/test"]
-
-os.system("mkdir -p %s" % ' '.join(DIRS_TO_MAKE))
 
 datestr = "%d%.2d%.2d_%s"%(date.today().year,date.today().month,date.today().day, time.strftime('%H%M%S'))
 


### PR DESCRIPTION
- Created separate variable for TEST_CONTIGS, which means rule dCGH runs on ALL_CONTIGS by default instead of just the contigs being tested
- Added rule test_call_filter which allows snakemake to recognize wildcards in rule genotype_refine_breakpoints_by_chr_subset
- Removed input requirements in rule clean_call_filter_test
